### PR TITLE
Use raw connection instead of raw vector with readr::read_delim, read_csv2

### DIFF
--- a/R/transfer_format_utils.R
+++ b/R/transfer_format_utils.R
@@ -186,8 +186,13 @@ storage_read_delim <- function(container, file, delim="\t", ...)
 
 storage_read_delim_readr <- function(container, file, delim="\t", ...)
 {
-    txt <- storage_download(container, file, NULL)
-    readr::read_delim(txt, delim=delim, ...)
+    con <- rawConnection(raw(0), "r+")
+    
+    on.exit(close(con))
+    
+    storage_download(container, file, con)
+    
+    readr::read_delim(con, delim=delim, ...)
 }
 
 

--- a/R/transfer_format_utils.R
+++ b/R/transfer_format_utils.R
@@ -236,8 +236,10 @@ storage_read_csv2 <- function(container, file, ...)
 
 storage_read_csv2_readr <- function(container, file, ...)
 {
-    txt <- storage_download(container, file, NULL)
-    readr::read_csv2(txt, ...)
+    con <- rawConnection(raw(0), "r+")
+    on.exit(close(con))
+    storage_download(container, file, con)
+    readr::read_csv2(con, ...)
 }
 
 

--- a/R/transfer_format_utils.R
+++ b/R/transfer_format_utils.R
@@ -187,11 +187,8 @@ storage_read_delim <- function(container, file, delim="\t", ...)
 storage_read_delim_readr <- function(container, file, delim="\t", ...)
 {
     con <- rawConnection(raw(0), "r+")
-    
     on.exit(close(con))
-    
     storage_download(container, file, con)
-    
     readr::read_delim(con, delim=delim, ...)
 }
 


### PR DESCRIPTION
In reference to #85

{readr} function's can read from a connection object. This can read larger datasets up 4 times faster

![image](https://user-images.githubusercontent.com/23486577/115904867-ec00f700-a42a-11eb-8405-8bd63f251367.png)

Same data from #85; The data has a size of `35,625,456` in the storage container and has `47,519` rows with `96` columns.

Let me know if this makes sense or if there is any downside to this. We use this method in my work environment and have not had any issues in production.