### PR TITLE
Change to use lubridate::dmy_hms to convert Date/time string to POSIXct

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     mime,
     openssl,
     xml2,
-    AzureRMR (>= 2.3.0)
+    AzureRMR (>= 2.3.0),
+    lubridate
 Suggests:
     AzureAuth,
     readr,

--- a/R/adls_client_funcs.R
+++ b/R/adls_client_funcs.R
@@ -337,7 +337,7 @@ list_adls_files <- function(filesystem, dir="/", info=c("all", "name"),
         if(!is.null(dfchunk$contentLength))
             dfchunk$contentLength <- as.numeric(dfchunk$contentLength)
         if(!is.null(dfchunk$lastModified))
-            dfchunk$lastModified <- as_datetime(dfchunk$lastModified)
+            dfchunk$lastModified <- as_datetime_internal(dfchunk$lastModified)
         names(dfchunk)[c(2, 3)] <- c("size", "isdir")
 
         if(all(dfchunk$permissions == ""))

--- a/R/blob_client_funcs.R
+++ b/R/blob_client_funcs.R
@@ -442,9 +442,9 @@ list_blobs <- function(container, dir="/", info=c("partial", "name", "all"),
             if(info == "all")
             {
                 if(!is.null(df$`Last-Modified`))
-                    df$`Last-Modified` <- as_datetime(df$`Last-Modified`)
+                    df$`Last-Modified` <- as_datetime_internal(df$`Last-Modified`)
                 if(!is.null(df$`Creation-Time`))
-                    df$`Creation-Time` <- as_datetime(df$`Creation-Time`)
+                    df$`Creation-Time` <- as_datetime_internal(df$`Creation-Time`)
                 cbind(df[c(namecol, sizecol, dircol, typecol)], df[-c(namecol, sizecol, dircol, typecol)])
             }
             else df[c(namecol, sizecol, dircol, typecol)]

--- a/R/storage_utils.R
+++ b/R/storage_utils.R
@@ -232,9 +232,9 @@ retry_transfer.response <- function(res)
 }
 
 
-as_datetime <- function(x, format="%a, %d %b %Y %H:%M:%S", tz="GMT")
+as_datetime_internal <- function(x, tz = "GMT")
 {
-    as.POSIXct(x, format=format, tz=tz)
+    lubridate::dmy_hms(x, tz = tz)
 }
 
 


### PR DESCRIPTION
This PR addresses the issue that the below columns in list_storage_files result become NA for some occasion.

- lastModified
- Last-Modified
- Creation-Time

### Switch to use lubridate::dmy_hms instead of as.POSIXct

`format="%a, %d %b %Y %H:%M:%S"` won't always work so use lubridate::dmy_hms to make it robust.

### Changed API name from as_datetime to as_datetime_internal

as_datetime name conflicts with lubirdate::as_datetime conflicts, so to make it less confusing, change the API name to  as_datetime_internal
