### PR TITLE
Add directory_depth to get_service_sas class method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureStor
 Title: Storage Management in 'Azure'
-Version: 3.6.1
+Version: 3.6.1.9000
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = c("aut", "cre")),
     person("Microsoft", role="cph")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# AzureStor 3.6.1.9000
+
+- Add missing `directory_depth` argument for the `az_storage$get_service_sas` method (#114)
+
 # AzureStor 3.6.1
 
 - Fix an issue when authenticating with a SAS and the connection is retried.

--- a/R/az_storage.R
+++ b/R/az_storage.R
@@ -133,11 +133,11 @@ public=list(
     },
 
     get_service_sas=function(key=self$list_keys()[1], resource, service, start=NULL, expiry=NULL, permissions="r",
-                             resource_type=NULL, ip=NULL, protocol=NULL, policy=NULL, snapshot_time=NULL)
+                             resource_type=NULL, ip=NULL, protocol=NULL, policy=NULL, snapshot_time=NULL, directory_depth=NULL)
     {
         get_service_sas(self, key=key, resource=resource, service=service, start=start, expiry=expiry,
                         permissions=permissions, resource_type=resource_type, ip=ip, protocol=protocol, policy=policy,
-                        snapshot_time=snapshot_time)
+                        snapshot_time=snapshot_time, directory_depth=directory_depth)
     },
 
     get_blob_endpoint=function(key=self$list_keys()[1], sas=NULL, token=NULL)

--- a/tests/testthat/test10a_service_sas.R
+++ b/tests/testthat/test10a_service_sas.R
@@ -92,6 +92,21 @@ test_that("Service SAS works with dir resource",
 })
 
 
+test_that("Service SAS from class method works with dir resource (#114)",
+{
+    contname <- make_name()
+    dirname <- make_name()
+
+    bsas <- stor$get_service_sas(resource=file.path(contname, dirname), service="blob",
+                                 permissions="rcwl", resource_type="d", directory_depth=1)
+    bl <- stor$get_blob_endpoint(key=NULL, sas=bsas)
+    expect_silent(cont <- create_storage_container(bl0, contname))
+    expect_silent(create_storage_dir(cont, dirname))
+    cont <- storage_container(bl, contname)
+    expect_silent(storage_upload(cont, "../resources/iris.csv", file.path(dirname, "iris.csv")))
+})
+
+
 teardown({
     bl <- stor$get_blob_endpoint()
     blconts <- list_storage_containers(bl)


### PR DESCRIPTION
Closes #114.

This PR adds `directory_depth` as an argument passed to `get_service_sas()` from the corresponding `az_storage` class method.
