### PR TITLE
Add autologin environment variables to azcopy_auth()

### DIFF
--- a/R/azcopy_auth.R
+++ b/R/azcopy_auth.R
@@ -10,7 +10,14 @@ azcopy_auth <- function(endpoint)
     env <- character(0)
     obj <- list(login=FALSE)
 
-    if(!is.null(endpoint$key))
+    if (Sys.getenv("AZCOPY_AUTO_LOGIN_TYPE") == "SPN")
+    {
+        env["AZCOPY_AUTO_LOGIN_TYPE"] <- "SPN"
+        env["AZCOPY_SPA_CLIENT_SECRET"] <- Sys.getenv("AZCOPY_SPA_CLIENT_SECRET")
+        env["AZCOPY_SPA_APPLICATION_ID"] <-  Sys.getenv("AZCOPY_SPA_APPLICATION_ID")
+        env["AZCOPY_TENANT_ID"] <- Sys.getenv("AZCOPY_TENANT_ID")
+    }
+    else if(!is.null(endpoint$key))
     {
         stop("AzCopy does not support authentication with a shared key", call.=FALSE)
         # env["ACCOUNT_NAME"] <- sub("\\..*$", "", httr::parse_url(endpoint$url)$hostname)


### PR DESCRIPTION
There have been some reported issues running `azcopy` in linux environments (e.g. [#1840](https://github.com/Azure/azure-storage-azcopy/issues/1840)), likely due to issues integrating with `keyctl`. We have been experiencing similar issues running on Ubuntu VMs and containers. Our solution is using `azcopy`'s [autologin with a service principal](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-a-service-principal-by-using-a-client-secret-1). This does not rely on `keyctl`, just a handful of environment variables. This PR sets the appropriate environment variables before calling `azcopy`. I've run only manual tests but it has worked out well for our workflow.

It would be great to get this functionality in. Happy for suggestions or changes.